### PR TITLE
ci: add Scala Steward to automatically check for new version of Scala dependencies

### DIFF
--- a/.github/workflows/check-dependencies-updates.yml
+++ b/.github/workflows/check-dependencies-updates.yml
@@ -1,0 +1,16 @@
+on:
+  schedule:
+    - cron: '0 6 * * 1-5'
+
+name: 🍄 Check dependencies updates
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  scala-steward:
+    runs-on: ubuntu-22.04
+    name: Check Scala project dependencies updates with Scala Steward
+    steps:
+      - uses: scala-steward-org/scala-steward-action@v2


### PR DESCRIPTION
It was previously set thanks to https://github.com/VirtusLab/scala-steward-repos but we prefer to configure it through GitHub Actions in order to be more explicit